### PR TITLE
Move pin entry above booking form

### DIFF
--- a/booking/Bookings.html
+++ b/booking/Bookings.html
@@ -9,6 +9,12 @@
       <span id="status-text"></span>
       <button id="status-clear" class="status-clear" aria-label="Clear status" onclick="setStatus('', 'info')">✖</button>
     </div>
+
+    <div class="pin-block">
+      <label for="input_pin">PIN (required for any changes to bookings)</label>
+      <input type="password" id="input_pin" placeholder="pin" />
+    </div>
+
     <div class="inline-form">
 
       <label>
@@ -32,10 +38,6 @@
 
       <label>
         <input id="input_pilotName" placeholder="pilot">
-      </label>
-
-      <label>
-        <input type="password" id="input_pin" placeholder="pin">
       </label>
 
       <button onclick="book()">Book</button>

--- a/booking/Styles.html
+++ b/booking/Styles.html
@@ -12,14 +12,14 @@
   --pad:              1rem;
 }
 
-/* Form container: wrapable flex, max 670px */
+/* Form container: single-row flex */
 .inline-form {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   width: 100%;
   max-width: 700px;
   box-sizing: border-box;
-  gap: var(--gap);
+  gap: 0.5rem;
   background: var(--clr-card);
   border: 1px solid var(--clr-border);
   border-radius: var(--radius);
@@ -54,12 +54,11 @@
 .inline-form #input_date,
 .inline-form #input_lengthHr,
 .inline-form #input_tailNumber,
-.inline-form #input_pilotName,
-.inline-form #input_pin, {
+.inline-form #input_pilotName {
   order: 0;
 }
 
-/* Second-row controls (pin, book) */
+/* Book button positioning */
 .inline-form button {
   order: 1;
   margin-left: auto;
@@ -70,12 +69,11 @@
 .inline-form #input_lengthHr   { height: 35px; width: 65px;  }
 .inline-form #input_tailNumber { height: 35px; width: 200px; }
 .inline-form #input_pilotName  { height: 35px; width: 96px; }
-.inline-form #input_pin        { height: 35px; width: 50px;  }
 
 /* Book button styling + fixed width */
 .inline-form button {
   height: 35px;
-  width: 163px;
+  width: 110px;
   padding: 0.6em 0em;
   background: var(--clr-primary);
   color: #fff;
@@ -117,6 +115,31 @@
 /* only show the “✖” when there’s text */
 .status-message.info .status-clear,
 .status-message.error .status-clear { visibility: visible; }
+
+/* Pin entry section */
+.pin-block {
+  display: flex;
+  align-items: center;
+  gap: var(--gap);
+  margin-bottom: var(--gap);
+  font-family: Roboto, sans-serif;
+  color: var(--clr-text);
+}
+
+.pin-block input {
+  padding: 0.5em;
+  height: 35px;
+  width: 50px;
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius);
+  background: var(--clr-bg);
+  font-size: 0.9rem;
+  box-sizing: border-box;
+}
+
+.pin-block label {
+  font-weight: 500;
+}
 
 
 /* Container: vertical stack of cards, left-aligned */


### PR DESCRIPTION
## Summary
- move PIN input to the top of the booking page
- create a `.pin-block` style for a clearer layout
- fix newline at EOF
- ensure PIN input uses `box-sizing: border-box` so its height matches other inputs
- keep booking form in a single row by reducing the gap and narrowing the `Book` button

## Testing
- `npm test` *(fails: package.json missing)*
- `dotnet --version` *(fails: command not found)*
- `sudo apt-get update`
- `sudo apt-get install -y dotnet-sdk-6.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68720838508083248fd65b59b7b87d87