### PR TITLE
Extend datetime placeholder to Chrome Android

### DIFF
--- a/booking/Bookings.html
+++ b/booking/Bookings.html
@@ -217,18 +217,20 @@
           .deleteBooking(id, pin);
       }
 
-      // show placeholder text for the datetime field when empty on Safari only
+      // show placeholder text for the datetime field when empty on Safari or
+      // Chrome running on Android
       const inputDate = document.getElementById('input_date');
       const datePlaceholder = document.getElementById('date-placeholder');
       const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-      if (isSafari && inputDate && datePlaceholder) {
+      const isChromeAndroid = /android/i.test(navigator.userAgent) && /chrome/i.test(navigator.userAgent);
+      if ((isSafari || isChromeAndroid) && inputDate && datePlaceholder) {
         function toggleDatePlaceholder() {
           datePlaceholder.style.display = inputDate.value ? 'none' : 'block';
         }
         toggleDatePlaceholder();
         inputDate.addEventListener('input', toggleDatePlaceholder);
       } else if (datePlaceholder) {
-        // hide on non-Safari browsers
+        // hide on unsupported browsers
         datePlaceholder.style.display = 'none';
       }
 


### PR DESCRIPTION
## Summary
- show custom date placeholder for Android Chrome as well as Safari

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873183078fc8324bc7a0f72e4788f05