### PR TITLE
Update placeholder logic for mobile Safari

### DIFF
--- a/booking/Bookings.html
+++ b/booking/Bookings.html
@@ -217,20 +217,21 @@
           .deleteBooking(id, pin);
       }
 
-      // show placeholder text for the datetime field when empty on Safari or
-      // Chrome running on Android
+      // show placeholder text for the datetime field when empty on Safari for
+      // iPhone/iPad or Chrome running on Android
       const inputDate = document.getElementById('input_date');
       const datePlaceholder = document.getElementById('date-placeholder');
       const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+      const isIOS = /iphone|ipad/i.test(navigator.userAgent);
       const isChromeAndroid = /android/i.test(navigator.userAgent) && /chrome/i.test(navigator.userAgent);
-      if ((isSafari || isChromeAndroid) && inputDate && datePlaceholder) {
+      if (((isSafari && isIOS) || isChromeAndroid) && inputDate && datePlaceholder) {
         function toggleDatePlaceholder() {
           datePlaceholder.style.display = inputDate.value ? 'none' : 'block';
         }
         toggleDatePlaceholder();
         inputDate.addEventListener('input', toggleDatePlaceholder);
       } else if (datePlaceholder) {
-        // hide on non-Safari, non-CromeAndroid browsers (e.g. Edge that shows built-in placeholder)
+        // hide on desktop Safari and other browsers that provide a built-in placeholder
         datePlaceholder.style.display = 'none';
       }
 


### PR DESCRIPTION
## Summary
- update placeholder detection to handle Safari on iOS specifically
- keep Chrome on Android behaviour
- hide label on desktop Safari and other browsers

## Testing
- `tidy -errors booking/Bookings.html`

------
https://chatgpt.com/codex/tasks/task_e_687bc32d26a883248c9d2e013a58edea