### PR TITLE
Align booking card badge borders with form inputs

### DIFF
--- a/booking/Styles.html
+++ b/booking/Styles.html
@@ -283,6 +283,7 @@ body {
   justify-content: center;
   height: var(--input-height);
   background: var(--clr-badge-bg);
+  border: 1px solid var(--clr-border);
   border-radius: 4px;
   padding: 0 0.5em;
   text-align: center;


### PR DESCRIPTION
## Summary
- Add a `1px` border to booking card badges to match form input styling.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891a51494e883249f27270652f0fe2d