### PR TITLE
Add Pangborn webcam and Chelan windgram docs pages

### DIFF
--- a/docs/pangborn-webcam
+++ b/docs/pangborn-webcam
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+      }
+
+      #keatcam {
+        max-width: 420px;
+        max-height: 420px;
+        width: auto;
+        height: auto;
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <a href="https://cam.pangbornairport.com/webcam/pawebcam.jpg" target="_blank" rel="noopener noreferrer">
+      <img id="keatcam" alt="Pangborn Airport webcam">
+    </a>
+
+    <script>
+      const rand = Math.floor(Math.random() * 1e8);
+      document.getElementById('keatcam').src = `https://cam.pangbornairport.com/webcam/pawebcam.jpg?${rand}`;
+    </script>
+  </body>
+</html>

--- a/docs/wxtofly.html
+++ b/docs/wxtofly.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+      }
+
+      #windgram {
+        max-width: 420px;
+        max-height: 420px;
+        width: auto;
+        height: auto;
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <a href="http://wxtofly.net/v2/explorer.html#Chelan" target="_blank" rel="noopener noreferrer">
+      <img id="windgram" alt="Chelan windgram">
+    </a>
+
+    <script>
+      const today = new Date();
+      const yyyy = today.getFullYear();
+      const mm = String(today.getMonth() + 1).padStart(2, '0');
+      const dd = String(today.getDate()).padStart(2, '0');
+      const rand = Math.floor(Math.random() * 1e8);
+
+      const wxtoflyChelan = `http://wxtofly.net/windgrams/${yyyy}-${mm}-${dd}_Chelan_windgram.png?${rand}`;
+      const windgramUrl = `https://images.weserv.nl/?url=${encodeURIComponent(wxtoflyChelan)}`;
+
+      document.getElementById('windgram').src = windgramUrl;
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation

- Provide lightweight embeddable pages to display the Pangborn Airport webcam and a Chelan windgram image for quick viewing or embedding in dashboards.

### Description

- Add `docs/pangborn-webcam`, a minimal HTML page that displays the Pangborn webcam image with a cache-busting query parameter to ensure fresh fetches and a link to the source feed.
- Add `docs/wxtofly.html`, a minimal HTML page that builds a dated `wxtofly` windgram URL for Chelan, proxies it via `https://images.weserv.nl/` and sets the image source with a cache-busting query parameter.

### Testing

- No automated tests were added or run for these static documentation files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee58d774788324a114def2c0bd8016)