### PR TITLE
Add simple HTML pages for Pangborn webcam and Wxtofly windgram

### DIFF
--- a/docs/pangborn-webcam
+++ b/docs/pangborn-webcam
@@ -1,0 +1,49 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+      }
+
+      a {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+      }
+
+      #keatcam {
+        display: block;
+        max-width: 100vw;
+        max-height: 100vh;
+        width: auto;
+        height: auto;
+        object-fit: contain;
+      }
+    </style>
+  </head>
+  <body>
+    <a href="https://cam.pangbornairport.com/webcam/pawebcam.jpg" target="_blank" rel="noopener noreferrer">
+      <img id="keatcam" alt="Pangborn Airport webcam">
+    </a>
+
+    <script>
+      const rand = Math.floor(Math.random() * 1e8);
+      document.getElementById('keatcam').src = `https://cam.pangbornairport.com/webcam/pawebcam.jpg?${rand}`;
+    </script>
+  </body>
+</html>

--- a/docs/wxtofly.html
+++ b/docs/wxtofly.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+      }
+
+      #windgram {
+        max-width: 420px;
+        max-height: 420px;
+        width: auto;
+        height: auto;
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <a href="http://wxtofly.net/v2/explorer.html#Chelan" target="_blank" rel="noopener noreferrer">
+      <img id="windgram" alt="Chelan windgram">
+    </a>
+
+    <script>
+      const today = new Date();
+      const yyyy = today.getFullYear();
+      const mm = String(today.getMonth() + 1).padStart(2, '0');
+      const dd = String(today.getDate()).padStart(2, '0');
+      const rand = Math.floor(Math.random() * 1e8);
+
+      const wxtoflyChelan = `http://wxtofly.net/windgrams/${yyyy}-${mm}-${dd}_Chelan_windgram.png?${rand}`;
+      const windgramUrl = `https://images.weserv.nl/?url=${encodeURIComponent(wxtoflyChelan)}`;
+
+      document.getElementById('windgram').src = windgramUrl;
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide lightweight documentation pages that embed the Pangborn Airport webcam and a Chelan windgram for quick viewing and linking.

### Description
- Add `docs/pangborn-webcam`: a minimal responsive HTML page that displays the Pangborn Airport webcam image with a cache-busting query parameter and wraps it in a link to the source.
- Add `docs/wxtofly.html`: a minimal HTML page that constructs today's Chelan windgram URL, proxies it through `https://images.weserv.nl/`, appends a cache-busting query parameter, and displays it as a linked image.

### Testing
- No automated tests were added or run for these static documentation files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee58d774788324a114def2c0bd8016)