### PR TITLE
Center Pangborn webcam and fit to iframe bounds

### DIFF
--- a/docs/pangborn-webcam.html
+++ b/docs/pangborn-webcam.html
@@ -6,11 +6,27 @@
       html, body {
         margin: 0;
         padding: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      a {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
       }
 
       #keatcam {
-        max-width: 420px;
-        max-height: 420px;
+        max-width: 100%;
+        max-height: 100%;
         width: auto;
         height: auto;
         display: block;


### PR DESCRIPTION
### Motivation
- Ensure the Pangborn Airport webcam image embedded in a Google Sites iframe is centered and scales to the iframe's available width or height so it never overflows or appears off-center. 

### Description
- Make the page fill available iframe space by adding `width: 100%` and `height: 100%` on `html, body` and enable flex centering on `body` so the content is centered both vertically and horizontally. 
- Make the anchor container fill the viewport and use flex centering so click-through behavior is preserved while keeping the image centered. 
- Replace the fixed `max-width: 420px` / `max-height: 420px` limits with responsive `max-width: 100%` and `max-height: 100%` on `#keatcam` so the image scales to the hosting iframe's bounds. 

### Testing
- Verified the resulting diff for `docs/pangborn-webcam.html` and confirmed the expected style and layout changes were present. 
- Printed and inspected the final file contents with line numbers to ensure the new CSS and layout structure were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee625a1ab48324a250d091dafebf3d)