### PR TITLE
Center wxtofly windgram and fit iframe bounds

### DIFF
--- a/docs/wxtofly.html
+++ b/docs/wxtofly.html
@@ -6,11 +6,27 @@
       html, body {
         margin: 0;
         padding: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      a {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
       }
 
       #windgram {
-        max-width: 420px;
-        max-height: 420px;
+        max-width: 100%;
+        max-height: 100%;
         width: auto;
         height: auto;
         display: block;


### PR DESCRIPTION
### Motivation
- Ensure the wxtofly windgram image centers and scales to the hosting iframe (match the behavior used by the Pangborn webcam page).
- Prevent the image from being clipped by the iframe by making the page fill the available iframe viewport and letting the image use the iframe's max width or height.

### Description
- Set `html, body` to `width: 100%` and `height: 100%` so the embedded document fills the hosting iframe.
- Make `body` a flex container and stretch the anchor to full width and height to center the image horizontally and vertically.
- Change `#windgram` constraints from fixed `420px` to `max-width: 100%` and `max-height: 100%` so the image scales while preserving aspect ratio.
- No runtime or URL logic changes; only presentation and layout CSS were modified; no skill from the session skills list was used.

### Testing
- Ran `git -C /workspace/cssweb status --short` and it completed successfully.
- Ran `git -C /workspace/cssweb diff -- docs/wxtofly.html` and it completed successfully to review the change.
- Created the commit (`git commit`) and inspected with `git -C /workspace/cssweb show --stat --oneline HEAD`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee63b075fc832493ac6b4d96f6bf1b)